### PR TITLE
Make IntrospectionRetriever and QueryRetriever public

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>io.fria</groupId>
   <artifactId>lilo</artifactId>
-  <version>23.4.1</version>
+  <version>23.4.0</version>
 
   <name>lilo</name>
   <description>Lilo GraphQL stitching library</description>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>io.fria</groupId>
   <artifactId>lilo</artifactId>
-  <version>23.4.0</version>
+  <version>23.4.1</version>
 
   <name>lilo</name>
   <description>Lilo GraphQL stitching library</description>

--- a/src/main/java/io/fria/lilo/IntrospectionRetriever.java
+++ b/src/main/java/io/fria/lilo/IntrospectionRetriever.java
@@ -3,7 +3,7 @@ package io.fria.lilo;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-interface IntrospectionRetriever<T> {
+public interface IntrospectionRetriever<T> {
 
   @NotNull
   T get(

--- a/src/main/java/io/fria/lilo/QueryRetriever.java
+++ b/src/main/java/io/fria/lilo/QueryRetriever.java
@@ -3,7 +3,7 @@ package io.fria.lilo;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-interface QueryRetriever<T> {
+public interface QueryRetriever<T> {
 
   @NotNull
   T get(


### PR DESCRIPTION
When using Kotlin, there are problems using Lilo because IntrospectionRetriever and QueryRetriever are not public.

java.lang.IllegalAccessError: failed to access class io.fria.lilo.IntrospectionRetriever from class ...

Seems to stem from this Kotlin bug, so you can consider this PR a workaround.
https://youtrack.jetbrains.com/issue/KT-11700